### PR TITLE
Refresh profile README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,31 @@
-[![CoolerVoid's github stats](https://github-readme-stats.vercel.app/api?username=Toymak3r&show_icons=true&theme=vision-friendly-dark&count_private=true)](https://github.com/anuraghazra/github-readme-stats)
+# Toymak3r 👋
+
+**Full-stack developer focused on creative projects, games, and media.**  
+Building fresh, expressive software and sharing the journey in public.
+
+## Current Focus
+- Leveling up in TypeScript, React, and Node.js
+- Prototyping small games and interactive tools
+- Shipping small, polished apps and learning in the open
+
+## Skills Snapshot
+- **Frontend:** React, TypeScript, HTML, CSS
+- **Backend:** Node.js, APIs, automation scripts
+- **Interests:** Game dev, media tooling, developer experience
+
+## Highlights & Projects
+- [Do Abismo PodCast](https://anchor.fm/doabismo) — Horror media podcast (PT-BR)
+- [Baixa Resolução PodCast](https://anchor.fm/baixaresolucao) — Tech + culture with an acid twist (PT-BR)
+- [Ludoravia PodCast](https://anchor.fm/ludoravia) — Game development & related topics (PT-BR)
+- [Boca do Inferno](https://bocadoinferno.com.br/author/ed-toy-facundo/) — News, comics, movies reviews (PT-BR)
+- [From Abyss Media](https://www.fromabyss.com) — Media PR
+- [Alvanista](https://alvanista.com) — Social network for and by gamers
+
+## GitHub Activity
+[![Toymak3r's GitHub stats](https://github-readme-stats.vercel.app/api?username=Toymak3r&show_icons=true&theme=vision-friendly-dark&count_private=true)](https://github.com/anuraghazra/github-readme-stats)
 
 [![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=toymak3r&layout=compact)](https://github.com/anuraghazra/github-readme-stats)
 
-## Projects 
-
-[Do Abismo PodCast](https://anchor.fm/doabismo) - Podcast about the horror genre in your sort of medias (PT-BR)
-
-[Baixa Resolução PodCast](https://anchor.fm/baixaresolucao) - Podcast about technology and topics related with some acid tasty (PT-BR)
-
-[Ludoravia PodCast](https://anchor.fm/ludoravia) - Podcast about gamedevelopment and topics related (PT-BR)
-
-[Boca do Inferno](https://bocadoinferno.com.br/author/ed-toy-facundo/) - News, Comics, Movies Reviews (PT-BR)
-
-[From Abyss Media](https://www.fromabyss.com) - Media PR.
-
-[Alvanista](https://alvanista.com) - Social Networking Media for and by Gamers.
+## Let's Connect
+- Open to collaborations on creative dev projects
+- Reach out via GitHub issues or discussions


### PR DESCRIPTION
### Motivation
- Modernize the profile `README.md` to present a fresher, clearer developer summary and public-facing focus areas.
- Reorganize badges and project links so GitHub activity and highlights are easier to read.
- Improve copy and layout to make the repository a better outlet for programming skills and collaboration.

### Description
- Replace the previous badge-first layout with a header, concise intro, and a new `Current Focus` section.
- Add `Skills Snapshot` and `Highlights & Projects` sections and move GitHub statistics into a `GitHub Activity` area.
- Update wording and formatting for clarity and a more inviting presentation.
- File modified: `README.md`.

### Testing
- No automated tests were required for this documentation-only change.
- No CI or unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965fbd15944833399471f2e7a21034a)