### PR TITLE
Fix README Top Langs image username casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Building fresh, expressive software and sharing the journey in public.
 ## GitHub Activity
 [![Toymak3r's GitHub stats](https://github-readme-stats.vercel.app/api?username=Toymak3r&show_icons=true&theme=vision-friendly-dark&count_private=true)](https://github.com/anuraghazra/github-readme-stats)
 
-[![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=toymak3r&layout=compact)](https://github.com/anuraghazra/github-readme-stats)
+[![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=Toymak3r&layout=compact)](https://github.com/anuraghazra/github-readme-stats)
 
 ## Let's Connect
 - Open to collaborations on creative dev projects


### PR DESCRIPTION
### Motivation
- The Top Langs badge in the README was not rendering correctly, likely due to a casing mismatch in the external stats service URL.
- Ensure the GitHub stats service receives the exact repository username so images display as expected.

### Description
- Updated `README.md` to change the Top Langs badge URL from `username=toymak3r` to `username=Toymak3r`.
- Kept the rest of the GitHub stats badges and README content unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965fccb963c8333940437d7949ac015)